### PR TITLE
Remove response template prefix

### DIFF
--- a/behavior/scripts/index.js
+++ b/behavior/scripts/index.js
@@ -29,7 +29,7 @@ exports.handle = function handle(client) {
     },
 
     prompt() {
-      client.addResponse('app:response:name:prompt/weather_city')
+      client.addResponse('prompt/weather_city')
       client.done()
     },
   })
@@ -61,7 +61,7 @@ exports.handle = function handle(client) {
         }
 
         console.log('sending real weather:', weatherData)
-        client.addResponse('app:response:name:provide_weather/current', weatherData)
+        client.addResponse('provide_weather/current', weatherData)
         client.done()
 
         callback()


### PR DESCRIPTION
As of v0.0.7 of the Node.js SDK, the `addResponse` method no longer *requires* `app:response:name:` as a prefix. This updates the default JS script.